### PR TITLE
remove js customization requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # glpc_related-entries
 Related Entries Docker app for OJS 3.0
 
-### The following changes have to be made before running the code:
-1. /app/src/static/crossRefBlock.js, line 5: Supply value for dockerApiUrl
-2. /app/src/static/relatedEntries.js, line 4: Supply value for dockerApiUrl
+## Microservice
+A nodejs microservice stores submission-submission relationships in a mysql database
+
+## Javascript UI
+Javascript files enable a backend UI for interaction with the microservice, and enable a public UI to render the relationships on the article landing page.
+
+## A pilot project
+This functionality demonstrates the value of a [generalized solution to interlink submissions in PKP OJS/OPS/OMP](https://forum.pkp.sfu.ca/t/interlinking-submissions-preprints-reviews-related-submissions/73783), with the hope that further development may be done to enable this as a built-in feature.

--- a/app/src/static/js/crossRefBlock.js
+++ b/app/src/static/js/crossRefBlock.js
@@ -2,7 +2,7 @@
 // Designed by Bryan Klausmeyer
 
 const currentEntryId = window.location.href.split('/').pop();
-const dockerApiUrl = ""; // Full URL (and, where applicable, port) for public-facing Docker app (no forward slash at end)
+const dockerApiUrl = () => new URL(document.currentScript.src).origin;
 const url = `${dockerApiUrl}/items?entryId=${currentEntryId}`;
 
 function fetchJsonData(url) {

--- a/app/src/static/js/relatedEntries.js
+++ b/app/src/static/js/relatedEntries.js
@@ -1,7 +1,7 @@
 // Cross-References 1.0 (Client Side: OJS Backend)
 // Designed by Bryan Klausmeyer
 
-var dockerApiUrl = ""; // Full URL (and, where applicable, port) for public-facing Docker app (no forward slash at end)
+const dockerApiUrl = () => new URL(document.currentScript.src).origin;
 var currentEntryId;
 
 var cache = {};


### PR DESCRIPTION
Use the `document.currentScript.src` to avoid needing to hardcode the microservice host.
Replace the hardcoding instructions in README with some app description.