### PR TITLE
Abstract Section IDs

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,6 +11,8 @@ RUN npm install -g envsub
 COPY . .
 
 ARG OJS_BASE_URI
+ARG OJS_SECTION_IDS
+
 RUN envsub -d --syntax handlebars ./src/static/js/crossRefBlock.js
 RUN envsub -d --syntax handlebars ./src/static/js/relatedEntries.js
 

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       OJS_PROTOCOL_AND_DNS: ${OJS_PROTOCOL_AND_DNS}
       OJS_BASE_URI: ${OJS_BASE_URI}
       OJS_API_KEY: ${OJS_API_KEY}
+      OJS_SECTION_IDS: ${OJS_SECTION_IDS}
 
   mysql:
     image: mysql:8.0

--- a/app/env.template
+++ b/app/env.template
@@ -1,9 +1,13 @@
-# === CORS Headers ===
+# ====================
+# CORS Headers =======
+# ====================
 
-# Multiple allowed origin URLs possible
-ALLOWED_ORIGINS = ["A", "B", "C"]
+# Multiple allowed origin URLs possible, e.g.: ALLOWED_ORIGINS = ["A", "B", "C"]
+ALLOWED_ORIGINS = 
 
-# === Database ===
+# ====================
+# Docker DB ==========
+# ====================
 
 MYSQL_HOST=
 MYSQL_USER=
@@ -11,19 +15,26 @@ MYSQL_PASSWORD=
 MYSQL_ROOT_PASSWORD=
 MYSQL_DB=
 
-# === OJS API ===
+# ====================
+# OJS Config =========
+# ====================
 
 # Full URL for OJS 3.x, e.g.: https://myurl.com (no forward slash at end)
 OJS_PROTOCOL_AND_DNS=
+
 # Full URL for OJS 3.x, e.g.: /ojs/JournalPath (include any initial forward slash, but no forward slash at end)
 OJS_BASE_URI=
-# Example: https://my-open-journal.com/ojs/index.php/MOJ/
-# OJS_PROTOCOL_AND_DNS=https://my-open-journal.com
-# OJS_BASE_URI=/ojs/index.php/MOJ
-# Example: https://another-journal.com/
-# OJS_PROTOCOL_AND_DNS=https://www.another-journal.com
-# OJS_BASE_URI=
 
+## Example 1: https://my-open-journal.com/ojs/index.php/MOJ/
+## -> OJS_PROTOCOL_AND_DNS=https://my-open-journal.com
+## -> OJS_BASE_URI=/ojs/index.php/MOJ
+
+## Example 2: https://another-journal.com/
+## -> OJS_PROTOCOL_AND_DNS=https://www.another-journal.com
+## -> OJS_BASE_URI=
 
 # OJS API key. For more info, see here: https://docs.pkp.sfu.ca/dev/api/ojs/3.4#tag/Authentication
 OJS_API_KEY=
+
+# Specify which journal section(s) are displayed in the app, e.g.: OJS_SECTION_IDS:1,2,3,4 (a single value can also be given)
+OJS_SECTION_IDS=

--- a/app/src/static/js/relatedEntries.js
+++ b/app/src/static/js/relatedEntries.js
@@ -282,16 +282,21 @@ function searchSubmissions(request, response) {
 
 		response(cachedResults);
 	} else {
+
+		var sectionIds = "{{OJS_SECTION_IDS}}".split(',');
+
+		var requestData = {
+			searchPhrase: request.term,
+			count: 25,
+			status: '3,5',
+			sectionIds: sectionIds
+		};
+		
 		$.ajax({
 			url: dockerApiUrl + '/api/data',
 			method: "GET",
 			dataType: "json",
-			data: {
-				searchPhrase: request.term,
-				count: 25,
-				status: '3,5',
-				sectionIds: 1
-			},
+			data: data: requestData,
 			success: function(data) {
 				var suggestions = [];
 				for (var i = 0; i < data.length; i++) {


### PR DESCRIPTION
These updates resolve issue #6. The changes to the code have been tested and work.

One issue of course is that OJS does not provide journal managers with an easy way to figure out what the section IDs are. The only way to do this is to examine the OJS JSON output. I think it would be to the benefit of journal managers to have those ID numbers exposed in the OJS journal settings (subtly).