### PR TITLE
fullTitle: Language agnostic code

### DIFF
--- a/app/src/routes/data.js
+++ b/app/src/routes/data.js
@@ -43,7 +43,31 @@ router.get('/data', (req, res) => {
 			// Extract the publication information
 			const publications = data.publications || [];
 			const firstPublication = publications[0] || {};
-			const fullTitle = firstPublication.fullTitle && firstPublication.fullTitle.en_US;
+			let fullTitle = '';
+
+			if (firstPublication.fullTitle) {
+				// Use the locale at the submission level as the language
+				const language = data.locale || "en_US"; // Default to "en_US" if no locale is provided
+
+				// Check if the language is available in the fullTitle object
+				if (firstPublication.fullTitle[language]) {
+					fullTitle = firstPublication.fullTitle[language];
+				} else {
+					// If the language is not available, fallback to the default language (en_US)
+					if (firstPublication.fullTitle.en_US) {
+						fullTitle = firstPublication.fullTitle.en_US;
+					} else {
+						// If the default (en_US) is not available, use any available language as a backup
+						for (const lang in firstPublication.fullTitle) {
+							if (firstPublication.fullTitle[lang]) {
+								fullTitle = firstPublication.fullTitle[lang];
+								break;
+							}
+						}
+					}
+				}
+			}
+
 			const status = firstPublication.status;
 
 			// Create the response object with the extracted information


### PR DESCRIPTION
This change should make the code for getting the 'fullTitle' object in OJS JSON language-agnostic. It extracts the first publication's data, then tries to determine the appropriate language to use for the title by checking the "locale" variable at the submission level. If the specified language is available in the "fullTitle" object, it selects the corresponding title; otherwise, it falls back to the default language "en_US" or any available language title.

I have tested this code and it doesn't break anything (although I feel like maybe it makes it slightly slower to load, though hard to say), but I haven't tried to switch the submission language, since I'm not sure how to do that in OJS.

This should resolve issue #8 