### PR TITLE
fullTitle: Language agnostic code (part 2)

### DIFF
--- a/app/src/routes/data.js
+++ b/app/src/routes/data.js
@@ -43,7 +43,31 @@ router.get('/data', (req, res) => {
 			// Extract the publication information
 			const publications = data.publications || [];
 			const firstPublication = publications[0] || {};
-			const fullTitle = firstPublication.fullTitle && firstPublication.fullTitle.en_US;
+			let fullTitle = '';
+
+			if (firstPublication.fullTitle) {
+				// Use the locale at the submission level as the language
+				const language = data.locale || "en_US"; // Default to "en_US" if no locale is provided
+
+				// Check if the language is available in the fullTitle object
+				if (firstPublication.fullTitle[language]) {
+					fullTitle = firstPublication.fullTitle[language];
+				} else {
+					// If the language is not available, fallback to the default language (en_US)
+					if (firstPublication.fullTitle.en_US) {
+						fullTitle = firstPublication.fullTitle.en_US;
+					} else {
+						// If the default (en_US) is not available, use any available language as a backup
+						for (const lang in firstPublication.fullTitle) {
+							if (firstPublication.fullTitle[lang]) {
+								fullTitle = firstPublication.fullTitle[lang];
+								break;
+							}
+						}
+					}
+				}
+			}
+
 			const status = firstPublication.status;
 
 			// Create the response object with the extracted information

--- a/app/src/routes/data.js
+++ b/app/src/routes/data.js
@@ -13,9 +13,15 @@ const apiKey = process.env.OJS_API_KEY;
 // });
 
 router.get('/data', (req, res) => {
+
+	// TWO OPTIONS FOR RETRIEVING DATA:
+	//    A) ENTRY ID (ONE ENTRY)
+	//    B) SEARCH PHRASE (MULTIPLE ENTRIES)
+	
 	const { id, searchPhrase, count, status, sectionIds } = req.query;
 
-	// Check the endpoint requested
+	// A) IF DATA IS REQUESTED FOR A SPECIFIC ENTRY USING THE ID, DO THIS:
+	
 	if (id) {
 		// Handle request for a specific submission ID
 		fetch(`${apiUrl}/submissions/${id}`, {
@@ -82,6 +88,9 @@ router.get('/data', (req, res) => {
 			console.error('Error:', error);
 			res.sendStatus(500); // Return an error status in case of failure
 		});
+
+	// B) ELSE IF DATA IS REQUESTED USING A SEARCH PHRASE, DO THIS:
+	
 	} else if (searchPhrase) {
 		// Handle request for searching submissions
 		const params = new URLSearchParams({
@@ -109,12 +118,29 @@ router.get('/data', (req, res) => {
 					const formattedData = data.items.map(item => {
 						if (item.publications && item.publications.length > 0) {
 							const publication = item.publications[0];
-							if (publication.fullTitle && publication.fullTitle.en_US) {
-								return {
-									id: item.id,
-									title: publication.fullTitle.en_US
-								};
+							let title = '';
+
+							const language = item.locale || "en_US"; // Default to "en_US" if no locale is provided
+
+							if (publication.fullTitle && publication.fullTitle[language]) {
+								title = publication.fullTitle[language];
+							} else {
+								if (publication.fullTitle && publication.fullTitle.en_US) {
+									title = publication.fullTitle.en_US;
+								} else {
+									for (const lang in publication.fullTitle) {
+										if (publication.fullTitle[lang]) {
+											title = publication.fullTitle[lang];
+											break;
+										}
+									}
+								}
 							}
+							
+							return {
+								id: item.id,
+								title: title
+							};
 						}
 						return null;
 					}).filter(item => item !== null);


### PR DESCRIPTION
Updated the second part of the code (retrieving entry data using searchPhrase) to make the fullTitle attribute language agnostic. Like the first method (retrieve data for a specific entry ID), it will default to en_US if no other language is specified.

This code hasn't been tested yet but it should work.