### PR TITLE
Update crossRefBlock.js

### DIFF
--- a/app/src/static/js/crossRefBlock.js
+++ b/app/src/static/js/crossRefBlock.js
@@ -93,6 +93,10 @@ function createList(data) {
 				const titleB = titles[ids.indexOf(b.related_entry_id)];
 				return titleA.localeCompare(titleB);
 			});
+			
+			if (data.length === 0) {
+				return null;
+			}
 
 			const list = document.createElement('ul');
 			list.id = 'entries_list';


### PR DESCRIPTION
I do not have my dev computer on me, so I cannot verify if this works, but I think it should prevent the Cross Ref Block from displaying on the individual entry pages if no data is associated with said entry.

This is intended to resolve #24 